### PR TITLE
Update superagent to ^0.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent-retry",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A retrying layer for a superagent request",
   "keywords": [
     "superagent",
@@ -13,13 +13,13 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "superagent": "~0.17.0"
+    "superagent": "^0.18.0"
   },
   "devDependencies": {
     "mocha": "*",
     "should": "*",
     "express": "~3.3.8",
-    "superagent": "~0.17.0"
+    "superagent": "^0.18.0"
   },
   "main": "lib/index"
 }


### PR DESCRIPTION
Hello,

A new superagent version has been published :)
They strictly follow semver versioning rules so you can switch to "^" symbol.
