### PR TITLE
Retain request path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,17 +53,26 @@ function retry (retries) {
 
 
 /**
- * HACK: Resets the internal state of a request:
+ * HACK: Resets the internal state of a request.
  */
 
 function reset (request, timeout) {
   var headers = request.req._headers;
+  var path = request.req.path;
+
   request.req.abort();
   request.called = false;
   request.timeout(timeout);
   delete request.req;
   delete request._timer;
-  for (var k in headers) request.set(k, headers[k]);
+
+  for (var k in headers) {
+    request.set(k, headers[k]);
+  }
+
+  if (!request.qs) {
+    request.req.path = path;
+  }
 }
 
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "superagent": "~0.20.0"
+    "superagent": "*"
   },
   "devDependencies": {
     "mocha": "*",

--- a/test/test.js
+++ b/test/test.js
@@ -155,5 +155,25 @@ describe('superagent-retry', function () {
           done();
         });
     });
+
+    it('should retry with the same querystring', function(done){
+      var requests = 0;
+
+      app.get('/qs-data', function(req, res){
+        if (++requests > 10) return res.json({ foo: req.query.foo });
+        res.setTimeout(1);
+      });
+
+      var url = 'http://localhost:' + port + '/qs-data';
+
+      agent
+        .get(url)
+        .retry(20)
+        .query({ foo: 'bar' })
+        .end(function(err, res){
+          res.body.foo.should.eql('bar');
+          done();
+        })
+    });
   });
 })


### PR DESCRIPTION
Retain the original request path for older versions of superagent that stored the path string on the request we are deleting here.

NOTE: newer versions store it differently so they were not effected by this bug. https://github.com/visionmedia/superagent/pull/331/files
