### PR TITLE
fix bug where req doesn't exist

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,6 +57,10 @@ function retry (retries) {
  */
 
 function reset (request, timeout) {
+  if (!request && !request.req) {
+    return;
+  }
+  
   var headers = request.req._headers;
   var path = request.req.path;
 


### PR DESCRIPTION
fix bug where req doesn't exist, causing req._headers to bomb out.