### PR TITLE
Fixing `peerDependency` issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,15 +11,13 @@
     "type": "git",
     "url": "git://github.com/segmentio/superagent-retry.git"
   },
-  "dependencies": {},
-  "peerDependencies": {
-    "superagent": "*"
+  "dependencies": {
+    "superagent": "~0.20.0"
   },
   "devDependencies": {
     "mocha": "*",
     "should": "*",
-    "express": "~3.3.8",
-    "superagent": "~0.20.0"
+    "express": "~3.3.8"
   },
   "main": "lib/index"
 }


### PR DESCRIPTION
Since NPM@3, `peerDependencies` no longer cause anything to be implicitly installed. Instead, npm will now warn if a packages `peerDependencies` are missing.

I moved the `devDependency` up, so when `npm install --production` occurs, the `dependency` is still installed.