### PR TITLE
Fix query duplication

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,7 @@ module.exports.retries = retries;
 function retry (retries) {
 
   var self    = this
+    , oldPath = this.url
     , oldEnd  = this.end;
 
   retries = retries || 1;
@@ -38,7 +39,7 @@ function retry (retries) {
       return oldEnd.call(self, function (err, res) {
         if (!retries || !shouldRetry(err, res)) return fn && fn(err, res);
 
-        reset(self, timeout);
+        reset(self, oldPath, timeout);
 
         retries--;
         return attemptRetry();
@@ -56,9 +57,9 @@ function retry (retries) {
  * HACK: Resets the internal state of a request.
  */
 
-function reset (request, timeout) {
+function reset (request, url, timeout) {
   var headers = request.req._headers;
-  var path = request.req.path;
+  var path = request.url;
 
   request.req.abort();
   request.called = false;

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,13 +28,12 @@ function retry (retries) {
 
   var self    = this
     , oldPath = this.url
+    , timeout = this._timeout
     , oldEnd  = this.end;
 
   retries = retries || 1;
 
   this.end = function (fn) {
-    var timeout = this._timeout;
-
     function attemptRetry () {
       return oldEnd.call(self, function (err, res) {
         if (!retries || !shouldRetry(err, res)) return fn && fn(err, res);
@@ -58,22 +57,28 @@ function retry (retries) {
  */
 
 function reset (request, url, timeout) {
-  var headers = request.req._headers;
-  var path = request.url;
+  if (request.req) {
+    var headers = request.req._headers;
+    var path = request.url;
 
-  request.req.abort();
-  request.called = false;
-  request.timeout(timeout);
-  delete request.req;
+    request.req.abort();
+    request.called = false;
+    delete request.req;
+
+    for (var k in headers) {
+      request.set(k, headers[k]);
+    }
+
+    if (!request.qs) {
+      request.req.path = path;
+    }
+  } else {
+    request.abort();
+    request.clearTimeout();
+  }
+
   delete request._timer;
-
-  for (var k in headers) {
-    request.set(k, headers[k]);
-  }
-
-  if (!request.qs) {
-    request.req.path = path;
-  }
+  request.timeout(timeout);
 }
 
 


### PR DESCRIPTION
Hey there; I've got a pair of fixes:

* When requests with querystrings were retried, the path would amend the querystring every time the request was made
* Timeouts weren't being cleared properly due to `requests.req` not existing (maybe that's a thing only on newer superagents? I'm on 1.3.0)

I'm happy to split this into two separate PRs as well.

Thanks!