### PR TITLE
retry when connection refused

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,6 +28,7 @@ function onresponse (err, res) {
   Currently the retrying logic checks for:
 
   * ECONNRESET
+  * ECONNREFUSED
   * ETIMEDOUT
   * EADDRINFO
   * ESOCKETTIMEDOUT

--- a/lib/retries.js
+++ b/lib/retries.js
@@ -4,6 +4,7 @@
 
 module.exports = [
   econnreset,
+  econnrefused,
   etimedout,
   eaddrinfo,
   esockettimedout,
@@ -21,6 +22,13 @@ function econnreset (err, res) {
   return err && err.code === 'ECONNRESET';
 }
 
+/**
+ * Connection refused detection
+ */
+
+function econnrefused (err, res) {
+  return err && err.code === 'ECONNREFUSED';
+}
 
 /**
  * Timeout detection

--- a/test/test.js
+++ b/test/test.js
@@ -196,6 +196,28 @@ describe('superagent-retry', function () {
         });
     });
 
+    it('should retry on server connection refused', function (done) {
+      var url = 'http://localhost:' + (port+1) + '/hello';
+      var request = agent.get(url);
+      var allowedRetries = 10;
+      var allowedTries = allowedRetries + 1;
+      var triesCount = 0
+
+      var oldEnd = request.end;
+      request.end = function(fn) {
+        triesCount++;
+        oldEnd.call(request, fn);
+      };
+
+      request
+        .retry(allowedRetries)
+        .end(function (err, res) {
+          err.code.should.eql('ECONNREFUSED');
+          triesCount.should.eql(allowedTries);
+          done();
+        });
+    });
+
     it('should retry with the same querystring', function(done){
       var requests = 0;
 


### PR DESCRIPTION
This pull request enable support for on connection refused retries. This is a common case when the backend uses a load balancer, where instances might get replaced in the middle of the connection creation.