### PR TITLE
Check for cross domain error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,21 +57,24 @@ function retry (retries) {
  */
 
 function reset (request, timeout) {
-  var headers = request.req._headers;
-  var path = request.req.path;
-
-  request.req.abort();
   request.called = false;
   request.timeout(timeout);
-  delete request.req;
   delete request._timer;
 
-  for (var k in headers) {
-    request.set(k, headers[k]);
-  }
+  if (request.req) {
+    var headers = request.req._headers;
+    var path = request.req.path;
 
-  if (!request.qs) {
-    request.req.path = path;
+    request.req.abort();
+    delete request.req;
+
+    for (var k in headers) {
+      request.set(k, headers[k]);
+    }
+
+    if (!request.qs) {
+      request.req.path = path;
+    }
   }
 }
 

--- a/lib/retries.js
+++ b/lib/retries.js
@@ -8,6 +8,7 @@ module.exports = [
   etimedout,
   eaddrinfo,
   esockettimedout,
+  crossDomain,
   gateway,
   timeout,
   internal
@@ -54,6 +55,14 @@ function eaddrinfo (err, res) {
 
 function esockettimedout (err, res) {
   return err && err.code === 'ESOCKETTIMEDOUT';
+}
+
+/**
+ * Superagent crossDomain error
+ */
+
+function crossDomain (err, res) {
+  return err && err.crossDomain;
 }
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -81,7 +81,6 @@ describe('superagent-retry', function () {
           .get('http://localhost:' + port)
           .retry(5)
           .end(function (err, res) {
-            console.log('requests', requests)
             res.text.should.eql('hello!');
             requests.should.eql(4);
             done(err);


### PR DESCRIPTION
When issuing a CORS request on a bad connection the browser immediately fails because it can't issue an `OPTIONS` request. Superagent throws an error with `crossDomain: true` property. Should retry because connection may be unstable and next try may succeed.

`request.req` is null when a cross domain error occurs, so I added a condition there.
