### PR TITLE
Retry on user defined errors. Delay retries

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,15 +24,22 @@ module.exports.retries = retries;
  * @param  {Number} count
  */
 
-function retry (retries) {
+function retry (retries, userShouldRetry) {
 
   var self    = this
-    , oldEnd  = this.end;
+    , oldEnd  = this.end
+    , noop  = function () { return false; };
 
   retries = retries || 1;
+  userShouldRetry = userShouldRetry || noop;
 
   this.end = function (fn) {
     var timeout = this._timeout;
+
+    function shouldRetry (err, res) {
+      return baseShouldRetry(err, res) || userShouldRetry(err, res);
+    }
+
 
     function attemptRetry () {
       return oldEnd.call(self, function (err, res) {
@@ -83,6 +90,6 @@ function reset (request, timeout) {
  * @return {Boolean}
  */
 
-function shouldRetry (err, res) {
+function baseShouldRetry (err, res) {
   return retries.some(function (check) { return check(err, res); });
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ var retries = require('./retries');
 module.exports = function (superagent) {
   var Request = superagent.Request;
   Request.prototype.retry = retry;
+  Request.prototype.delayRetry = delayRetry;
   return superagent;
 };
 
@@ -30,6 +31,7 @@ function retry (retries, userShouldRetry) {
     , oldEnd  = this.end
     , noop  = function () { return false; };
 
+  this._delayRetryTime = this._delayRetryTime || 0;
   retries = retries || 1;
   userShouldRetry = userShouldRetry || noop;
 
@@ -42,14 +44,16 @@ function retry (retries, userShouldRetry) {
 
 
     function attemptRetry () {
-      return oldEnd.call(self, function (err, res) {
-        if (!retries || !shouldRetry(err, res)) return fn && fn(err, res);
+      setTimeout(function () {
+        return oldEnd.call(self, function (err, res) {
+          if (!retries || !shouldRetry(err, res)) return fn && fn(err, res);
 
-        reset(self, timeout);
+          reset(self, timeout);
 
-        retries--;
-        return attemptRetry();
-      });
+          retries--;
+          return attemptRetry();
+        });
+      }, self._delayRetryTime);
     }
 
     return attemptRetry();
@@ -80,6 +84,17 @@ function reset (request, timeout) {
   if (!request.qs) {
     request.req.path = path;
   }
+}
+
+
+/**
+ * Waits a certain time before retrying
+ */
+
+function delayRetry (miliseconds) {
+  this._delayRetryTime = miliseconds;
+
+  return this;
 }
 
 


### PR DESCRIPTION
This PR does two things:
1. It allows the user to provide a callback to indicate that a request has to be retried
2. It allows the user to wait before retrying

I know this doesn't sound like the "usual" scenario but I wanted to have the code out there so that people could find it. If you guys find it useful I can split it in two PRs

I've had to use it many times in scenarios when client's APIs don't consistently return 200 and when I know I have to wait before their autoscaling kicks in. I know it's not ideal, but some things are simply out of your control.

Thanks for this library BTW!
