### PR TITLE
Add optional `delay` argument

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,26 +22,28 @@ module.exports.retries = retries;
 /**
  * Sets the amount of times to retry the request
  * @param  {Number} count
+ * @param  {Number} [delay] optional delay in ms
  */
 
-function retry (retries) {
+function retry (retries, delay) {
 
   var self    = this
     , oldEnd  = this.end;
 
-  retries = retries || 1;
+  retries     = retries === Number(retries) && retries || 1;
+  delay       = delay === Number(delay) && delay || 0;
 
   this.end = function (fn) {
     var timeout = this._timeout;
 
     function attemptRetry () {
       return oldEnd.call(self, function (err, res) {
-        if (!retries || !shouldRetry(err, res)) return fn && fn(err, res);
+        if (!retries-- || !shouldRetry(err, res)) return fn && fn(err, res);
 
-        reset(self, timeout);
-
-        retries--;
-        return attemptRetry();
+        setTimeout(function() {
+          reset(self, timeout);
+          attemptRetry()
+        }, delay);
       });
     }
 
@@ -65,6 +67,7 @@ function reset (request, timeout) {
   request.timeout(timeout);
   delete request.req;
   delete request._timer;
+  delete request._endCalled;
 
   for (var k in headers) {
     request.set(k, headers[k]);


### PR DESCRIPTION
Optionally delay retries by the specified amount of milliseconds.

```javascript
superagent
  .get('https://segment.io')
  .retry(2, 800) // retry twice with 0.8s delay before responding
  .end(onresponse);
```

Convenient for servers that only err when too busy.