### PR TITLE
Add deprecation note to the README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,6 +5,11 @@
 
   [superagent]: https://github.com/visionmedia/superagent
 
+
+## Deprecated
+
+Retries are now natively supported by `superagent`: http://visionmedia.github.io/superagent/#retrying-requests.
+
 ## Usage
 
 ```javascript


### PR DESCRIPTION
This PR points folks to the `superagent` documentation for retries, because retry is natively supported by superagent.

I'd suggest deprecating the package [on npm too](https://docs.npmjs.com/cli/deprecate).