### PR TITLE
Add unmaintained warning

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,7 @@
+# ⚠️ Unmaintained ⚠️
+
+This repository is unmaintained, and this [functionality has been added to superagent core](https://visionmedia.github.io/superagent/#retrying-requests).
+
 # superagent-retry
 
   Extends the node version of [`visionmedia/superagent`][superagent]'s `Request`, adds a `.retry` method to add retrying logic to the request. Calling this will retry the request however many additional times you'd like.


### PR DESCRIPTION
Relating to #21, add an "unmaintained" warning to this library
and include links to the superagent respository.